### PR TITLE
Versione basata su passport-saml con il supporto a IDP multipli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # spid-passport
-Passport authentication provider for SPID
+Provider di autenticazione Passport per SPID
 
-Questo modulo consente di autenticare i vostri utenti tramite Spid (Servizio Publico per L'Identificazione Digitale) 
-nella vostra app nodejs
+Questo modulo consente di autenticare gli utenti tramite SPID (Servizio Publico di Identità Digitale) 
+nelle applicazioni Nodejs che fanno uso di [Passport](http://www.passportjs.org).
 
 ## Installazione
 
@@ -12,20 +12,26 @@ $ npm install spid-passport
 
 ## Utilizzo
 ### Configurazione
-Sono necessari i parametri di configurazione per l'Identity Provider e per i diversi Service Provider e nello specifico il costruttore prende in input due oggetti e una callback di verifica:
+Sono necessari i parametri di configurazione del Service Provider e dei
+diversi Identity Provider; nello specifico il costruttore prende in input
+due oggetti e una callback di verifica.
+Le opzioni possibili sono tutte quelle messe a disposizione dalla libreria
+[passport-saml](https://github.com/bergie/passport-saml#config-parameter-details),
+con l'unica differenza che i parametri relativi agli Identity Provider sono
+ripetuti per ciascun Identity Provider supportato da SPID. I parametri obbligatori sono:
 
 ##### Service Provider: 
-- (String) `issuer` - Nome entita che fornisce il servizio
+- (String) `issuer` - Id dell'entita che fornisce il servizio, può essere qualsiasi cosa, tipicamente è la URL del Service Provider
 - (String) `privateCert` - Chiave privata del Service Provider (Formato PEM)
-- (String) `path` - Endpoint sul quale ricevere la response dall'identity provider
-- (String) `attributeConsumingServiceIndex` - Indice posizionale sul metadata che identifica il set di attributi richiesti all'Identity Provider
-- (String) `identifierFormat` - Formato dell'identificativo dell'utente
-- (String) `authnContext` - Livello SPID richiesto (ad es.: https://www.spid.gov.it/SpidL1)
+- (String) `path` - Endpoint sul quale ricevere la response dall'identity provider; viene combinata con le informazioni dell'host per costruire una url completa
+- (Number) `attributeConsumingServiceIndex` - Indice posizionale sul metadata che identifica il set di attributi richiesti all'Identity Provider
+- (String) `identifierFormat` - Formato dell'identificativo dell'utente, per SPID va valorizzato a `urn:oasis:names:tc:SAML:2.0:nameid-format:transient`
+- (String) `authnContext` - Livello SPID richiesto (a scelta tra: https://www.spid.gov.it/SpidL1, https://www.spid.gov.it/SpidL2, https://www.spid.gov.it/SpidL3)
 
 ##### Identity Provider
 
-- (String) `entryPoint` - Endpoint per effettuare il login, verra effettuato un redirect
-- (String) `cert` - Certificati dell' Identity Provider (Formato PEM)
+- (String) `entryPoint` - Endpoint per effettuare il login, verrà effettuato un redirect verso questa URL
+- (String) `cert` - Certificato dell'Identity Provider (Formato PEM)
 
 
 ## Esempio di utilizzo con express e spid-test-env

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ app.use(passport.initialize())
 let spidStrategy = new SpidStrategy({
   sp: {
     path: "/acs",
-    issuer: "http://italia-backend",
+    issuer: "http://issuer-name",
     privateCert: fs.readFileSync("./certs/key.pem", "utf-8"),
     attributeConsumingServiceIndex: 1,
     identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
@@ -70,7 +70,7 @@ passport.use(spidStrategy)
 
 app.get("/login", passport.authenticate('spid'))
 
-app.post("/assert",
+app.post("/acs",
   passport.authenticate('spid', {session: false}),
   function(req, res){
     console.log(req.user)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ app.post("/acs",
   })
 
 // Create xml metadata
-app.get("/metadata", spidStrategy.createMetadata())
+app.get("/metadata", spidStrategy.generateServiceProviderMetadata())
 
 
 app.listen(3000);

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ let spidStrategy = new SpidStrategy({
     test: {
       entryPoint: "https://spid-testenv-identityserver:9443/samlsso",
       cert: "MIICNTCCAZ6gAwIBAgIES343gjANBgkqhkiG9w0BAQUFADBVMQswCQYD..."
-    }
+    },
     idp2: {
       entryPoint: "https://...",
       cert: "..."
@@ -75,7 +75,7 @@ let spidStrategy = new SpidStrategy({
 
   // Find or create user
   console.log(profile)
-  done()
+  done(null, profile);
 })
 
 passport.use(spidStrategy)

--- a/README.md
+++ b/README.md
@@ -56,8 +56,14 @@ let spidStrategy = new SpidStrategy({
     authnContext: "https://www.spid.gov.it/SpidL1"
   },
   idp: {
-    entryPoint: "https://spid-testenv-identityserver:9443/samlsso",
-    cert: "MIICNTCCAZ6gAwIBAgIES343gjANBgkqhkiG9w0BAQUFADBVMQswCQYD..."
+    test: {
+      entryPoint: "https://spid-testenv-identityserver:9443/samlsso",
+      cert: "MIICNTCCAZ6gAwIBAgIES343gjANBgkqhkiG9w0BAQUFADBVMQswCQYD..."
+    }
+    idp2: {
+      entryPoint: "https://...",
+      cert: "..."
+    }
   }
 }, function(profile, done){
 

--- a/example/index.js
+++ b/example/index.js
@@ -33,10 +33,10 @@ let spidStrategy = new SpidStrategy({
 
   // Find or create your user
   console.log('all done!!!!!', profile)
-  done()
+  done(null, profile);
 })
 
- passport.use(spidStrategy)
+passport.use(spidStrategy)
 
 app.get("/login", passport.authenticate('spid'))
 

--- a/example/index.js
+++ b/example/index.js
@@ -17,7 +17,7 @@ app.use(passport.initialize())
 let spidStrategy = new SpidStrategy({
   sp: {
     path: "/acs",
-    issuer: "http://italia-backend",
+    issuer: "http://issuer-name",
     privateCert: fs.readFileSync("./certs/key.pem", "utf-8"),
     attributeConsumingServiceIndex: 1,
     identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
@@ -38,7 +38,7 @@ let spidStrategy = new SpidStrategy({
 
 app.get("/login", passport.authenticate('spid'))
 
-app.post("/assert",
+app.post("/acs",
   passport.authenticate('spid', {session: false}),
   function(req, res){
     console.log(req.user)

--- a/example/index.js
+++ b/example/index.js
@@ -16,15 +16,16 @@ app.use(passport.initialize())
 
 let spidStrategy = new SpidStrategy({
   sp: {
-    entity_id: 'hackdev',
-    private_key: fs.readFileSync("./certs/key.pem").toString(),
-    certificate: fs.readFileSync("./certs/cert.pem").toString(),
-    assert_endpoint: "http://hackdev.it:3000/assert",
+    path: "/acs",
+    issuer: "http://italia-backend",
+    privateCert: fs.readFileSync("./certs/key.pem", "utf-8"),
+    attributeConsumingServiceIndex: 1,
+    identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+    authnContext: "https://www.spid.gov.it/SpidL1"
   },
   idp: {
-    sso_login_url: "https://spid-testenv-identityserver:9443/samlsso",
-    sso_logout_url: "https://spid-testenv-identityserver:9443/samlsso",
-    certificates: fs.readFileSync("./certs/idp.certificate.crt").toString()
+    entryPoint: "https://spid-testenv-identityserver:9443/samlsso",
+    cert: "MIICNTCCAZ6gAwIBAgIES343gjANBgkqhkiG9w0BAQUFADBVMQswCQYD..."
   }
 }, function(profile, done){
 
@@ -33,12 +34,12 @@ let spidStrategy = new SpidStrategy({
   done()
 })
 
- passport.use('Spid', spidStrategy)
+ passport.use(spidStrategy)
 
-app.get("/login", passport.authenticate('Spid'))
+app.get("/login", passport.authenticate('spid'))
 
 app.post("/assert",
-  passport.authenticate('Spid', {session: false}),
+  passport.authenticate('spid', {session: false}),
   function(req, res){
     console.log(req.user)
     res.send(`Hello ${req.user.name_id}`)

--- a/example/index.js
+++ b/example/index.js
@@ -24,8 +24,10 @@ let spidStrategy = new SpidStrategy({
     authnContext: "https://www.spid.gov.it/SpidL1"
   },
   idp: {
-    entryPoint: "https://spid-testenv-identityserver:9443/samlsso",
-    cert: "MIICNTCCAZ6gAwIBAgIES343gjANBgkqhkiG9w0BAQUFADBVMQswCQYD..."
+    test: {
+      entryPoint: "https://spid-testenv-identityserver:9443/samlsso",
+      cert: "MIICNTCCAZ6gAwIBAgIES343gjANBgkqhkiG9w0BAQUFADBVMQswCQYD..."
+    }
   }
 }, function(profile, done){
 

--- a/example/index.js
+++ b/example/index.js
@@ -48,7 +48,7 @@ app.post("/acs",
   })
 
 // Create xml metadata
-app.get("/metadata", spidStrategy.createMetadata())
+app.get("/metadata", spidStrategy.generateServiceProviderMetadata())
 
 
 app.listen(3000);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "passport": "^0.4.0",
     "passport-strategy": "^1.0.0",
-    "saml2-js": "^1.12.2"
+    "passport-saml": "^0.31.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
L'implementazione corrente ha due limitazioni:

- non supporta la possibilità di avere idp multipli, cosa che invece è necessaria nel contesto SPID
- richiede una modifica alla libreria saml2-js per impostare **attributeConsumingServiceIndex** sull'asserzione di richiesta. Senza questo l'idp autentica con successo l'utente ma non restituisce nessun attributo al service provider

Questa versione risolve entrambi i problemi estendendo passport-saml. Sono da finalizzare i controlli sulle opzioni e la documentazione.