### PR TITLE
Metadata SPID

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,22 @@ app.use(passport.initialize())
 
 let spidStrategy = new SpidStrategy({
   sp: {
-    path: "/acs",
-    issuer: "http://issuer-name",
+    callbackUrl: "https://example.com/acs",
+    issuer: "https://example.com",
     privateCert: fs.readFileSync("./certs/key.pem", "utf-8"),
+    decryptionPvk: fs.readFileSync("./certs/key.pem", "utf-8"),
     attributeConsumingServiceIndex: 1,
     identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
     authnContext: "https://www.spid.gov.it/SpidL1"
+    attributes: {
+      name: "Required attributes",
+      attributes: ["fiscalNumber", "name", "familyName", "email"]
+    },
+    organization: {
+      name: "Organization name",
+      displayName: "Organization display name",
+      URL: "https://example.com"
+    }
   },
   idp: {
     test: {

--- a/example/index.js
+++ b/example/index.js
@@ -16,12 +16,22 @@ app.use(passport.initialize())
 
 let spidStrategy = new SpidStrategy({
   sp: {
-    path: "/acs",
-    issuer: "http://issuer-name",
+    callbackUrl: "https://example.com/acs",
+    issuer: "https://example.com",
     privateCert: fs.readFileSync("./certs/key.pem", "utf-8"),
+    decryptionPvk: fs.readFileSync("./certs/key.pem", "utf-8"),
     attributeConsumingServiceIndex: 1,
     identifierFormat: "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
     authnContext: "https://www.spid.gov.it/SpidL1"
+    attributes: {
+      name: "Required attributes",
+      attributes: ["fiscalNumber", "name", "familyName", "email"]
+    },
+    organization: {
+      name: "Organization name",
+      displayName: "Organization display name",
+      URL: "https://example.com"
+    }
   },
   idp: {
     test: {

--- a/index.js
+++ b/index.js
@@ -135,7 +135,108 @@ SpidStrategy.prototype.generateServiceProviderMetadata = function(
 ) {
   const spidOptions = this.spidOptions.sp;
   const samlClient = new saml(spidOptions);
-  return samlClient.generateServiceProviderMetadata(decryptionCert);
+
+  const metadata = {
+    'EntityDescriptor' : {
+      '@xmlns': 'urn:oasis:names:tc:SAML:2.0:metadata',
+      '@xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
+      '@entityID': spidOptions.issuer,
+      '@ID': spidOptions.issuer.replace(/\W/g, '_'),
+      'SPSSODescriptor' : {
+        '@protocolSupportEnumeration': 'urn:oasis:names:tc:SAML:2.0:protocol',
+        '@AuthnRequestsSigned': true,
+        '@WantAssertionsSigned': true,
+      },
+    }
+  };
+
+  if (spidOptions.decryptionPvk) {
+    if (!decryptionCert) {
+      throw new Error(
+        "Missing decryptionCert while generating metadata for decrypting service provider");
+    }
+
+    decryptionCert = decryptionCert.replace( /-+BEGIN CERTIFICATE-+\r?\n?/, '' );
+    decryptionCert = decryptionCert.replace( /-+END CERTIFICATE-+\r?\n?/, '' );
+    decryptionCert = decryptionCert.replace( /\r\n/g, '\n' );
+
+    metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = {
+      'ds:KeyInfo' : {
+        'ds:X509Data' : {
+          'ds:X509Certificate': {
+            '#text': decryptionCert
+          }
+        }
+      },
+      'EncryptionMethod' : [
+        // this should be the set that the xmlenc library supports
+        { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes256-cbc' },
+        { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes128-cbc' },
+        { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#tripledes-cbc' }
+      ]
+    };
+  }
+
+  if (spidOptions.logoutCallbackUrl) {
+    metadata.EntityDescriptor.SPSSODescriptor.SingleLogoutService = {
+      '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+      '@Location': spidOptions.logoutCallbackUrl
+    };
+  }
+
+  metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = spidOptions.identifierFormat;
+  metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
+    '@index': '1',
+    '@isDefault': 'true',
+    '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+    '@Location': samlClient.getCallbackUrl({})
+  };
+
+  metadata.EntityDescriptor.Signature = {
+    'SignedInfo': {
+      'CanonicalizationMethod': {
+        '@Algorithm': 'http://www.w3.org/2001/10/xml-exc-c14n#',
+        'SignatureMethod': {
+          '@Algorithm': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+        },
+        'Reference': {
+          '@URI': '#pfx9a8ea5db-ce3e-1f1d-ff15-c9b01ee53b32'
+        }
+      }
+    }
+  };
+
+//   ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+//     <ds:SignedInfo>
+//   <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+//     <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+//     <ds:Reference URI="#pfx9a8ea5db-ce3e-1f1d-ff15-c9b01ee53b32">
+//     <ds:Transforms>
+//   <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+//     <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+//     </ds:Transforms>
+//     <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+//     <ds:DigestValue>2Q/XUND+wHPnu97OW6jW55Oq/NBxCkVgNxnxaYACSP4=</ds:DigestValue>
+// </ds:Reference>
+// </ds:SignedInfo>
+//   <ds:SignatureValue>
+//     k+Di49omADHqK6hIOFVQiYRfAfoLtQP2KM3J+d6qTqA3vENaklMKMPo5v3XMwghtF1DcFOBv33X7Zf1XAp4XqbjIaqXv5nap2cOZm2prWHO3pl4RAXjMff+8pBYs1IzFKXjh+MOjhPfLy7DgTIzEFStYymv0yDm+W2DaQwU+P3n+PQI3xaPCwHsgLy0xXZdBZ1MEQSiOSMhIHUokacVQ2F5QYHgQ+CgVovZWJUktJMH8X6Bb/DMK7cAd+0bn+cMLXAH9OgUI1vne9E7FVmu3O0oRlbvR+ehnGoQU6+vvn/CnhIjp87roJJspsQOoPpG8iSI1D2R/Dn2r23uHpK6xDhw=
+//   </ds:SignatureValue>
+//   <ds:KeyInfo>
+//     <ds:X509Data>
+//       <ds:X509Certificate>
+//         MIIDczCCAlqgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBTMQswCQYDVQQGEwJpdDENMAsGA1UECAwEUm9tZTEUMBIGA1UECgwLYWdpZC5nb3YuaXQxHzAdBgNVBAMMFmh0dHBzOi8vaXRhbGlhLWJhY2tlbmQwHhcNMTcxMDI2MTAzNTQwWhcNMTgxMDI2MTAzNTQwWjBTMQswCQYDVQQGEwJpdDENMAsGA1UECAwEUm9tZTEUMBIGA1UECgwLYWdpZC5nb3YuaXQxHzAdBgNVBAMMFmh0dHBzOi8vaXRhbGlhLWJhY2tlbmQwggEjMA0GCSqGSIb3DQEBAQUAA4IBEAAwggELAoIBAgCXozdOvdlQhX2zyOvnpZJZWyhjmiRqkBW7jkZHcmFRceeoVkXGn4bAFGGcqESFMVmaigTEm1c6gJpRojo75smqyWxngEk1XLctn1+Qhb5SCbd2oHh0oLE5jpHyrxfxw8V+N2Hty26GavJE7i9jORbjeQCMkbggt0FahmlmaZr20akK8wNGMHDcpnMslJPxHl6uKxjAfe6sbNqjWxfcnirm05Jh5gYNT4vkwC1vx6AZpS2G9pxOV1q5GapuvUBqwNu+EH1ufMRRXvu0+GtJ4WtsErOakSF4KMezrMqKCrVPoK5SGxQMD/kwEQ8HfUPpim3cdi3RVmqQjsi/on6DMn/xTQIDAQABo1AwTjAdBgNVHQ4EFgQULOauBsRgsAudzlxzwEXYXd4uPyIwHwYDVR0jBBgwFoAULOauBsRgsAudzlxzwEXYXd4uPyIwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOCAQIAQOT5nIiAefn8FAWiVYu2uEsHpxUQ/lKWn1Trnj7MyQW3QA/jNaJHL/EpszJ5GONOE0lVEG1on35kQOWR7qFWYhH9Llb8EAAAb5tbnCiA+WIx4wjRTE3CNLulL8MoscacIc/rqWf5WygZQcPDX1yVxmK4F3YGG2qDTD3fr4wPweYHxn95JidTwzW8Jv46ajSBvFJ95CoCYL3BUHaxPIlYkGbJFjQhuoxo2XM4iT6KFD4IGmdssS4NFgW+OM+P8UsrYi2KZuyzSrHq5c0GJz0UzSs8cIDC/CPEajx2Uy+7TABwR4d20Hyo6WImIFJiDanROwzoG0YNd8aCWE8ZM2y81Ww=
+//       </ds:X509Certificate>
+//     </ds:X509Data>
+//   </ds:KeyInfo>
+// </ds:Signature>
+
+  // metadata.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+  // signer = crypto.createSign('RSA-SHA256');
+  // signer.update(querystring.stringify(metadata));
+  // metadata.Signature = signer.sign(spidOptions.privateCert, 'base64');
+
+  return xmlbuilder.create(metadata).end({ pretty: true, indent: '  ', newline: '\n' });
 };
 
 module.exports = SpidStrategy;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const passport = require("passport-strategy");
 const util = require("util");
+var xmlCrypto = require('xml-crypto');
+var xmlbuilder = require('xmlbuilder');
 const saml = require("passport-saml").SAML;
 
 function SpidStrategy(options, verify) {
@@ -137,12 +139,12 @@ SpidStrategy.prototype.generateServiceProviderMetadata = function(
   const samlClient = new saml(spidOptions);
 
   const metadata = {
-    'EntityDescriptor' : {
+    'EntityDescriptor': {
       '@xmlns': 'urn:oasis:names:tc:SAML:2.0:metadata',
       '@xmlns:ds': 'http://www.w3.org/2000/09/xmldsig#',
       '@entityID': spidOptions.issuer,
       '@ID': spidOptions.issuer.replace(/\W/g, '_'),
-      'SPSSODescriptor' : {
+      'SPSSODescriptor': {
         '@protocolSupportEnumeration': 'urn:oasis:names:tc:SAML:2.0:protocol',
         '@AuthnRequestsSigned': true,
         '@WantAssertionsSigned': true,
@@ -156,19 +158,19 @@ SpidStrategy.prototype.generateServiceProviderMetadata = function(
         "Missing decryptionCert while generating metadata for decrypting service provider");
     }
 
-    decryptionCert = decryptionCert.replace( /-+BEGIN CERTIFICATE-+\r?\n?/, '' );
-    decryptionCert = decryptionCert.replace( /-+END CERTIFICATE-+\r?\n?/, '' );
-    decryptionCert = decryptionCert.replace( /\r\n/g, '\n' );
+    decryptionCert = decryptionCert.replace(/-+BEGIN CERTIFICATE-+\r?\n?/, '');
+    decryptionCert = decryptionCert.replace(/-+END CERTIFICATE-+\r?\n?/, '');
+    decryptionCert = decryptionCert.replace(/\r\n/g, '\n');
 
     metadata.EntityDescriptor.SPSSODescriptor.KeyDescriptor = {
-      'ds:KeyInfo' : {
-        'ds:X509Data' : {
+      'ds:KeyInfo': {
+        'ds:X509Data': {
           'ds:X509Certificate': {
             '#text': decryptionCert
           }
         }
       },
-      'EncryptionMethod' : [
+      'EncryptionMethod': [
         // this should be the set that the xmlenc library supports
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes256-cbc' },
         { '@Algorithm': 'http://www.w3.org/2001/04/xmlenc#aes128-cbc' },
@@ -186,57 +188,78 @@ SpidStrategy.prototype.generateServiceProviderMetadata = function(
 
   metadata.EntityDescriptor.SPSSODescriptor.NameIDFormat = spidOptions.identifierFormat;
   metadata.EntityDescriptor.SPSSODescriptor.AssertionConsumerService = {
-    '@index': '1',
+    '@index': spidOptions.attributeConsumingServiceIndex,
     '@isDefault': 'true',
     '@Binding': 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
     '@Location': samlClient.getCallbackUrl({})
   };
 
-  metadata.EntityDescriptor.Signature = {
-    'SignedInfo': {
-      'CanonicalizationMethod': {
-        '@Algorithm': 'http://www.w3.org/2001/10/xml-exc-c14n#',
-        'SignatureMethod': {
-          '@Algorithm': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
-        },
-        'Reference': {
-          '@URI': '#pfx9a8ea5db-ce3e-1f1d-ff15-c9b01ee53b32'
-        }
-      }
+  if (spidOptions.attributes) {
+    function getFriendlyName(name) {
+      const friendlyNames = {
+        'name': 'Nome',
+        'familyName': 'Cognome',
+        'fiscalNumber': 'Codice fiscale',
+        'email': 'Email'
+      };
+
+      return friendlyNames[name];
     }
-  };
 
-//   ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
-//     <ds:SignedInfo>
-//   <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
-//     <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
-//     <ds:Reference URI="#pfx9a8ea5db-ce3e-1f1d-ff15-c9b01ee53b32">
-//     <ds:Transforms>
-//   <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
-//     <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
-//     </ds:Transforms>
-//     <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-//     <ds:DigestValue>2Q/XUND+wHPnu97OW6jW55Oq/NBxCkVgNxnxaYACSP4=</ds:DigestValue>
-// </ds:Reference>
-// </ds:SignedInfo>
-//   <ds:SignatureValue>
-//     k+Di49omADHqK6hIOFVQiYRfAfoLtQP2KM3J+d6qTqA3vENaklMKMPo5v3XMwghtF1DcFOBv33X7Zf1XAp4XqbjIaqXv5nap2cOZm2prWHO3pl4RAXjMff+8pBYs1IzFKXjh+MOjhPfLy7DgTIzEFStYymv0yDm+W2DaQwU+P3n+PQI3xaPCwHsgLy0xXZdBZ1MEQSiOSMhIHUokacVQ2F5QYHgQ+CgVovZWJUktJMH8X6Bb/DMK7cAd+0bn+cMLXAH9OgUI1vne9E7FVmu3O0oRlbvR+ehnGoQU6+vvn/CnhIjp87roJJspsQOoPpG8iSI1D2R/Dn2r23uHpK6xDhw=
-//   </ds:SignatureValue>
-//   <ds:KeyInfo>
-//     <ds:X509Data>
-//       <ds:X509Certificate>
-//         MIIDczCCAlqgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBTMQswCQYDVQQGEwJpdDENMAsGA1UECAwEUm9tZTEUMBIGA1UECgwLYWdpZC5nb3YuaXQxHzAdBgNVBAMMFmh0dHBzOi8vaXRhbGlhLWJhY2tlbmQwHhcNMTcxMDI2MTAzNTQwWhcNMTgxMDI2MTAzNTQwWjBTMQswCQYDVQQGEwJpdDENMAsGA1UECAwEUm9tZTEUMBIGA1UECgwLYWdpZC5nb3YuaXQxHzAdBgNVBAMMFmh0dHBzOi8vaXRhbGlhLWJhY2tlbmQwggEjMA0GCSqGSIb3DQEBAQUAA4IBEAAwggELAoIBAgCXozdOvdlQhX2zyOvnpZJZWyhjmiRqkBW7jkZHcmFRceeoVkXGn4bAFGGcqESFMVmaigTEm1c6gJpRojo75smqyWxngEk1XLctn1+Qhb5SCbd2oHh0oLE5jpHyrxfxw8V+N2Hty26GavJE7i9jORbjeQCMkbggt0FahmlmaZr20akK8wNGMHDcpnMslJPxHl6uKxjAfe6sbNqjWxfcnirm05Jh5gYNT4vkwC1vx6AZpS2G9pxOV1q5GapuvUBqwNu+EH1ufMRRXvu0+GtJ4WtsErOakSF4KMezrMqKCrVPoK5SGxQMD/kwEQ8HfUPpim3cdi3RVmqQjsi/on6DMn/xTQIDAQABo1AwTjAdBgNVHQ4EFgQULOauBsRgsAudzlxzwEXYXd4uPyIwHwYDVR0jBBgwFoAULOauBsRgsAudzlxzwEXYXd4uPyIwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOCAQIAQOT5nIiAefn8FAWiVYu2uEsHpxUQ/lKWn1Trnj7MyQW3QA/jNaJHL/EpszJ5GONOE0lVEG1on35kQOWR7qFWYhH9Llb8EAAAb5tbnCiA+WIx4wjRTE3CNLulL8MoscacIc/rqWf5WygZQcPDX1yVxmK4F3YGG2qDTD3fr4wPweYHxn95JidTwzW8Jv46ajSBvFJ95CoCYL3BUHaxPIlYkGbJFjQhuoxo2XM4iT6KFD4IGmdssS4NFgW+OM+P8UsrYi2KZuyzSrHq5c0GJz0UzSs8cIDC/CPEajx2Uy+7TABwR4d20Hyo6WImIFJiDanROwzoG0YNd8aCWE8ZM2y81Ww=
-//       </ds:X509Certificate>
-//     </ds:X509Data>
-//   </ds:KeyInfo>
-// </ds:Signature>
+    const attributes = spidOptions.attributes.attributes.map(function(item) {
+      return {
+        '@Name': item,
+        '@NameFormat': 'urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified',
+        '@FriendlyName': getFriendlyName(item)
+      };
+    })
 
-  // metadata.SigAlg = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
-  // signer = crypto.createSign('RSA-SHA256');
-  // signer.update(querystring.stringify(metadata));
-  // metadata.Signature = signer.sign(spidOptions.privateCert, 'base64');
+    metadata.EntityDescriptor.SPSSODescriptor.AttributeConsumingService = {
+      '@index': spidOptions.attributeConsumingServiceIndex,
+      'ServiceName': {
+        '@xml:lang': 'it',
+        '#text': spidOptions.attributes.name
+      },
+      'RequestedAttribute': attributes
+    }
+  }
 
-  return xmlbuilder.create(metadata).end({ pretty: true, indent: '  ', newline: '\n' });
+  if (spidOptions.organization) {
+    metadata.EntityDescriptor.Organization = {
+      'OrganizationName': spidOptions.organization.name,
+      'OrganizationDisplayName': spidOptions.organization.displayName,
+      'OrganizationURL': spidOptions.organization.URL
+    }
+  }
+
+  const xml = xmlbuilder.create(metadata).end({
+    pretty: true,
+    indent: '  ',
+    newline: '\n'
+  });
+
+  function MyKeyInfo(file) {
+    this.file = file;
+
+    this.getKeyInfo = function(key, prefix) {
+      prefix = prefix || '';
+      prefix = prefix ? prefix + ':' : prefix;
+      return "<" + prefix + "X509Data><X509Certificate>" + decryptionCert + "</X509Certificate></" + prefix + "X509Data>";
+    }
+
+    this.getKey = function(keyInfo) {
+      return this.file;
+    }
+  }
+
+  var sig = new xmlCrypto.SignedXml();
+  sig.signingKey = spidOptions.privateCert
+  sig.keyInfoProvider = new MyKeyInfo(decryptionCert)
+  sig.addReference("//*[local-name(.)='EntityDescriptor']", ['http://www.w3.org/2000/09/xmldsig#enveloped-signature', 'http://www.w3.org/2001/10/xml-exc-c14n#'], 'http://www.w3.org/2001/04/xmlenc#sha256')
+  sig.signatureAlgorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+  sig.computeSignature(xml)
+
+  return sig.getSignedXml();
 };
 
 module.exports = SpidStrategy;


### PR DESCRIPTION
Il generatore di metadata di passport-saml non è perfettamente compatibile con SPID, ho re-implementato la funzione `generateServiceProviderMetadata` in modo da renderlo compatibile.
Mancano sicuramente la validazione dei parametri e i test.